### PR TITLE
Removing origin header to fix an issue when using an headless chrome instance

### DIFF
--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -345,7 +345,6 @@ abstract class Protocol
             self::HEADER_UPGRADE => self::UPGRADE_VALUE,
             self::HEADER_CONNECTION => self::CONNECTION_VALUE,
             self::HEADER_KEY => $key,
-            self::HEADER_ORIGIN => $origin,
             self::HEADER_VERSION => (string) $this->getVersion(),
         ];
     }


### PR DESCRIPTION
The goal is to fix issue #15 . 
Removing the header makes it works.