### PR TITLE
[1.7] Add `getSocketResource` method to enhance socket management

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -290,24 +290,26 @@ class Client extends Configurable
     /**
      * Waits for data to become available on the socket.
      *
-     * @param float $maxSeconds The maximum amount of time to wait for data, in seconds.
-     * @return bool Returns true if data is available, false if the wait timed out.
+     * @param float $maxSeconds the maximum amount of time to wait for data, in seconds
+     *
+     * @return bool returns true if data is available, false if the wait timed out     
      */
     public function waitForData(float $maxSeconds): bool
     {
         $read = [$this->socket->getResource()];
         $write = null;
         $except = null;
-        $seconds = (int)floor($maxSeconds);
-        $microseconds = (int)(($maxSeconds - $seconds) * 1e6);
-        $result = socket_select($read, $write, $except, $seconds, $microseconds);
-        if ($result === false) {
+        $seconds = (int) \floor($maxSeconds);
+        $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
+        $result = \socket_select($read, $write, $except, $seconds, $microseconds);
+        if (false === $result) {
             // An error occurred
-            throw new RuntimeException('Error occurred during socket_select.');
-        } elseif ($result === 0) {
+            throw new \RuntimeException('Error occurred during socket_select.');
+        } elseif (0 === $result) {
             // Timeout occurred, no data available
             return false;
         }
+
         // Data is available
         return true;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -292,9 +292,9 @@ class Client extends Configurable
      *
      * @param float $maxSeconds the maximum amount of time to wait for data, in seconds
      *
-     * @return bool returns true if data is available, false if the wait timed out
+     * @return ?bool Returns true if data is available, false if the wait timed out, and null on error.
      */
-    public function waitForData(float $maxSeconds): bool
+    public function waitForData(float $maxSeconds): ?bool
     {
         $read = [$this->socket->getResource()];
         $write = null;
@@ -303,9 +303,8 @@ class Client extends Configurable
         $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
         $result = \stream_select($read, $write, $except, $seconds, $microseconds);
         if (false === $result) {
-            $errorcode = \socket_last_error($this->socket->getResource());
-            $errormsg = \socket_strerror($errorcode);
-            throw new \RuntimeException("socket_select error $errorcode: $errormsg");
+            // An error occurred. stream_select() probably triggered an error internally.
+            return null;
         } elseif (0 === $result) {
             // Timeout occurred, no data available
             return false;

--- a/src/Client.php
+++ b/src/Client.php
@@ -301,7 +301,7 @@ class Client extends Configurable
         $except = null;
         $seconds = (int) \floor($maxSeconds);
         $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
-        $result = \socket_select($read, $write, $except, $seconds, $microseconds);
+        $result = \stream_select($read, $write, $except, $seconds, $microseconds);
         if (false === $result) {
             $errorcode = \socket_last_error($this->socket->getResource());
             $errormsg = \socket_strerror($errorcode);

--- a/src/Client.php
+++ b/src/Client.php
@@ -286,6 +286,7 @@ class Client extends Configurable
 
         parent::configure($options);
     }
+
     /**
      * Retrieves the underlying socket resource.
      *

--- a/src/Client.php
+++ b/src/Client.php
@@ -303,8 +303,9 @@ class Client extends Configurable
         $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
         $result = \socket_select($read, $write, $except, $seconds, $microseconds);
         if (false === $result) {
-            // An error occurred
-            throw new \RuntimeException('Error occurred during socket_select.');
+            $errorcode = \socket_last_error($this->socket->getResource());
+            $errormsg = \socket_strerror($errorcode);
+            throw new \RuntimeException("socket_select error $errorcode: $errormsg");
         } elseif (0 === $result) {
             // Timeout occurred, no data available
             return false;

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,4 +296,28 @@ class Client extends Configurable
     {
         return $this->socket->getResource();
     }
+    /**
+     * Waits for data to become available on the socket.
+     *
+     * @param float $maxSeconds The maximum amount of time to wait for data, in seconds.
+     * @return bool Returns true if data is available, false if the wait timed out.
+     */
+    public function waitForData(float $maxSeconds): bool
+    {
+        $read = [$this->socket->getResource()];
+        $write = null;
+        $except = null;
+        $seconds = (int)floor($maxSeconds);
+        $microseconds = (int)(($maxSeconds - $seconds) * 1e6);
+        $result = socket_select($read, $write, $except, $seconds, $microseconds);
+        if ($result === false) {
+            // An error occurred
+            throw new RuntimeException('Error occurred during socket_select.');
+        } elseif ($result === 0) {
+            // Timeout occurred, no data available
+            return false;
+        }
+        // Data is available
+        return true;
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -292,7 +292,7 @@ class Client extends Configurable
      *
      * @param float $maxSeconds the maximum amount of time to wait for data, in seconds
      *
-     * @return bool returns true if data is available, false if the wait timed out     
+     * @return bool returns true if data is available, false if the wait timed out
      */
     public function waitForData(float $maxSeconds): bool
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -286,4 +286,13 @@ class Client extends Configurable
 
         parent::configure($options);
     }
+    /**
+     * Retrieves the underlying socket resource.
+     *
+     * @return resource The socket resource
+     */
+    public function getSocketResource()
+    {
+        return $this->socket->getResource();
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -288,15 +288,6 @@ class Client extends Configurable
     }
 
     /**
-     * Retrieves the underlying socket resource.
-     *
-     * @return resource The socket resource
-     */
-    public function getSocketResource()
-    {
-        return $this->socket->getResource();
-    }
-    /**
      * Waits for data to become available on the socket.
      *
      * @param float $maxSeconds The maximum amount of time to wait for data, in seconds.


### PR DESCRIPTION
This method is a prerequisite for eventually resolving https://github.com/chrome-php/chrome/issues/606

Here is my investigation notes leading up to this PR:
class \HeadlessChromium\Communication\Connection has a protected \HeadlessChromium\Communication\Socket\SocketInterface $wsClient;

\HeadlessChromium\Communication\Socket\SocketInterface has no getSocketResource().

\HeadlessChromium\Communication\Socket\Wrench must then create its own getSocketResource(), 
returning the resource from protected \Wrench\Client $client;
\Wrench\Client needs a getSocketResource(), returning it's socket resource from protected \Wrench\Socket\ClientSocket $socket;

\Wrench\Socket\ClientSocket inherits $this->socket property from UriSocket...

\Wrench\Socket\UriSocket inherits $this->socket property from \Wrench\Socket\AbstractSocket...

\Wrench\Socket\AbstractSocket has a public function getResource()

that means UriSocket has it too... that means ClientSocket also has it.. \Wrench\Client needs to expose it publicly (or at least protectedly)
it needs a
public function getSocketResource(){return $this->socket->getResource();}