### PR TITLE
PHP8.3 compatibility

### DIFF
--- a/examples/StatusApplication.php
+++ b/examples/StatusApplication.php
@@ -109,7 +109,7 @@ class StatusApplication implements ConnectionHandlerInterface
     {
         $data = [
             'type' => $type,
-            'text' => '['.\strftime('%m-%d %H:%M', \time()).'] '.$text,
+            'text' => '['.\date('m-d H:i', \time()).'] '.$text,
         ];
 
         $encodedData = $this->_encodeData('statusMsg', $data);


### PR DESCRIPTION
strftime was deprecated in PHP8.1.0.
This is the only PHP8.3.0 compatibility issue detected by the PHPCompatibility scanner git version right now:
```
hans@DESKTOP-EE15SLU:~/projects/PHPCompatibility$ ./vendor/bin/phpcs ../wrench/ --standard=PHPCompatibility

FILE: /home/hans/projects/wrench/examples/StatusApplication.php -------------------------------------------------------------------------------------------------------------------- FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------
 112 | WARNING | Function strftime() is deprecated since PHP 8.1; Use date() or IntlDateFormatter::format() instead
--------------------------------------------------------------------------------------------------------------------

Time: 710ms; Memory: 16MB
```
Related: https://github.com/chrome-php/wrench/pull/14 and https://github.com/chrome-php/chrome/issues/605