### PR TITLE
[1.6] Fix path whitespace edge case in tests

### DIFF
--- a/tests/Test/ServerTestHelper.php
+++ b/tests/Test/ServerTestHelper.php
@@ -134,6 +134,6 @@ final class ServerTestHelper implements LoggerAwareInterface
      */
     private function getCommand(): string
     {
-        return \sprintf('/usr/bin/env php ' . escapeshellarg(__DIR__ . '/server.php') . ' %d', $this->port);
+        return \sprintf('/usr/bin/env php '.\escapeshellarg(__DIR__.'/server.php').' %d', $this->port);
     }
 }

--- a/tests/Test/ServerTestHelper.php
+++ b/tests/Test/ServerTestHelper.php
@@ -134,6 +134,6 @@ final class ServerTestHelper implements LoggerAwareInterface
      */
     private function getCommand(): string
     {
-        return \sprintf('/usr/bin/env php '.\escapeshellarg(__DIR__.'/server.php').' %d', $this->port);
+        return \sprintf('/usr/bin/env php %s %d', \escapeshellarg(__DIR__.'/server.php'), $this->port);
     }
 }

--- a/tests/Test/ServerTestHelper.php
+++ b/tests/Test/ServerTestHelper.php
@@ -134,6 +134,6 @@ final class ServerTestHelper implements LoggerAwareInterface
      */
     private function getCommand(): string
     {
-        return \sprintf('/usr/bin/env php %s/server.php %d', __DIR__, $this->port);
+        return \sprintf('/usr/bin/env php ' . escapeshellarg(__DIR__ . '/server.php') . ' %d', $this->port);
     }
 }


### PR DESCRIPTION
if the file has a space in the path, the command would not account for that and generate an invalid invocation. for example if the path was /home/hans henrik/wrench/tests/Test/ServerTestHelper.php the command would previously fail.