### PR TITLE
PHP8.3 compatibility #2

### DIFF
--- a/tests/Test/ServerTestHelper.php
+++ b/tests/Test/ServerTestHelper.php
@@ -113,8 +113,8 @@ final class ServerTestHelper implements LoggerAwareInterface
             $this->pipes,
             __DIR__.'/../'
         );
-        if($this->process === false){
-            throw new \RuntimeException("proc_open failed: " . var_export(error_get_last(), true));
+        if (false === $this->process) {
+            throw new \RuntimeException('proc_open failed: '.\var_export(\error_get_last(), true));
         }
         \sleep(3);
     }

--- a/tests/Test/ServerTestHelper.php
+++ b/tests/Test/ServerTestHelper.php
@@ -111,9 +111,11 @@ final class ServerTestHelper implements LoggerAwareInterface
                 2 => ['file', $directory.'/server.err.log', 'a+'],
             ],
             $this->pipes,
-            __DIR__.'../'
+            __DIR__.'/../'
         );
-
+        if($this->process === false){
+            throw new \RuntimeException("proc_open failed: " . var_export(error_get_last(), true));
+        }
         \sleep(3);
     }
 


### PR DESCRIPTION
Turns out PHP<8.3's proc_open does not really care if the requested working_dir does not exist, while PHP>=8.3's proc_open bails if it does not exist.

And due to a typo in the code, the dir never existed.

And due to insufficient error checking, the error was not really detected.

Took fking 4 hours to track down: https://github.com/divinity76/wrench/pull/1
, and the fix is 1 byte 🤦‍♂️ 

Should probably complain to the php-src bugtracker, i am guessing the proc_open behavior change was unintentional (should at least be a E_DEPRECATED period "picking a non-existing working dir is deprecated and will stop working in a future version of PHP")