### PR TITLE
Use `random_bytes` function to generate mask

### DIFF
--- a/src/Frame/HybiFrame.php
+++ b/src/Frame/HybiFrame.php
@@ -131,13 +131,7 @@ class HybiFrame extends Frame
      */
     protected function generateMask()
     {
-        if (\extension_loaded('openssl')) {
-            return \openssl_random_pseudo_bytes(4);
-        } else {
-            // SHA1 is 128 bit (= 16 bytes)
-            // So we pack it into 32 bits
-            return \pack('N', \sha1(\spl_object_hash($this).\mt_rand(0, \PHP_INT_MAX).\uniqid('', true), true));
-        }
+        return \random_bytes(4);
     }
 
     /**


### PR DESCRIPTION
The original code was written for PHP<=5 where random_bytes did not exist yet.

Since PHP7.0.0 there is no reason to use openssl_random_pseudo_bytes or fallback to mt_rand/uniqid, 
random_bytes is always available.