### PR TITLE
Prevent blocking empty fread()

### DIFF
--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -254,7 +254,7 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                 $exceptArray = null;
                 $selectResult = @\stream_select($readArray, $writeArray, $exceptArray, 0);
                 if (
-                    // before the first fread(), stream_select() is unreliable (observed on PHP8.4.12 Ubuntu24.04)
+                    // before the first fread(), stream_select() is unreliable (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
                     !$this->hasBeenFreadInitialized
                     // > 0 means there is data to read
                     || $selectResult > 0

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -254,7 +254,7 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                 $exceptArray = null;
                 $selectResult = @\stream_select($readArray, $writeArray, $exceptArray, 0);
                 if (
-                    // before the first fread(), stream_select() is unreliable (observed on Ubuntu24.04)
+                    // before the first fread(), stream_select() is unreliable (observed on PHP8.4.12 Ubuntu24.04)
                     !$this->hasBeenFreadInitialized
                     // > 0 means there is data to read
                     || $selectResult > 0

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -57,6 +57,13 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
     protected $name;
 
     /**
+     * Whether we have ran fread() on the socket at least once.
+     * 
+     * @var bool
+     */
+    private $hasBeenFreadInitialized = false;
+
+    /**
      * Gets the IP address of the socket.
      *
      * @throws \Wrench\Exception\SocketException If the IP address cannot be obtained
@@ -242,9 +249,23 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
                     return $buffer;
                 }
-
-                $result = \fread($this->socket, $length);
-
+                $readArray = [$this->socket];
+                $writeArray = null;
+                $exceptArray = null;
+                $selectResult = @\stream_select($readArray, $writeArray, $exceptArray, 0);
+                if (
+                    // before the first fread(), stream_select() is unreliable (observed on Ubuntu24.04)
+                    !$this->hasBeenFreadInitialized
+                    // > 0 means there is data to read
+                    || $selectResult > 0
+                    // false means we were unable to check if there is data to read, it does not mean there is no data to read.
+                    || $selectResult === false
+                ) {
+                    $result = \fread($this->socket, $length);
+                    $this->hasBeenFreadInitialized = true;
+                } else {
+                    $result = false;
+                }
                 if ($makeBlockingAfterRead) {
                     \stream_set_blocking($this->socket, true);
                     $makeBlockingAfterRead = false;

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -254,7 +254,7 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                 $exceptArray = null;
                 $selectResult = @\stream_select($readArray, $writeArray, $exceptArray, 0);
                 if (
-                    // before the first fread(), stream_select() is unreliable (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
+                    // before the first fread(), stream_select() may erroneously return 0 (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
                     !$this->hasBeenFreadInitialized
                     // > 0 means there is data to read
                     || $selectResult > 0

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -262,7 +262,6 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                 // 1 means there is data to read, false means we were unable to check if there is data to read
                 if (1 === $selectResult || false === $selectResult) {
                     $result = \fread($this->socket, $length);
-                    $this->hasBeenFreadInitialized = true;
                 } else {
                     $result = false;
                 }

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -58,7 +58,7 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
     /**
      * Whether we have ran fread() on the socket at least once.
-     * 
+     *
      * @var bool
      */
     private $hasBeenFreadInitialized = false;
@@ -259,7 +259,7 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                     // > 0 means there is data to read
                     || $selectResult > 0
                     // false means we were unable to check if there is data to read, it does not mean there is no data to read.
-                    || $selectResult === false
+                    || false === $selectResult
                 ) {
                     $result = \fread($this->socket, $length);
                     $this->hasBeenFreadInitialized = true;

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -252,16 +252,16 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
                 if (!$this->hasBeenFreadInitialized) {
                     // stream_select() may erroneously return 0 before the first fread() (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
                     $this->hasBeenFreadInitialized = true;
-                    $selectResult                  = 1;
+                    $selectResult = 1;
                 } else {
-                    $readArray    = [$this->socket];
-                    $writeArray   = null;
-                    $exceptArray  = null;
+                    $readArray = [$this->socket];
+                    $writeArray = null;
+                    $exceptArray = null;
                     $selectResult = \stream_select($readArray, $writeArray, $exceptArray, 0);
                 }
                 // 1 means there is data to read, false means we were unable to check if there is data to read
-                if ($selectResult === 1 || $selectResult === false) {
-                    $result                        = \fread($this->socket, $length);
+                if (1 === $selectResult || false === $selectResult) {
+                    $result = \fread($this->socket, $length);
                     $this->hasBeenFreadInitialized = true;
                 } else {
                     $result = false;

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -249,23 +249,24 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
                     return $buffer;
                 }
-                $readArray = [$this->socket];
-                $writeArray = null;
-                $exceptArray = null;
-                $selectResult = @\stream_select($readArray, $writeArray, $exceptArray, 0);
-                if (
-                    // before the first fread(), stream_select() may erroneously return 0 (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
-                    !$this->hasBeenFreadInitialized
-                    // > 0 means there is data to read
-                    || $selectResult > 0
-                    // false means we were unable to check if there is data to read, it does not mean there is no data to read.
-                    || false === $selectResult
-                ) {
-                    $result = \fread($this->socket, $length);
+                if (!$this->hasBeenFreadInitialized) {
+                    // stream_select() may erroneously return 0 before the first fread() (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
+                    $this->hasBeenFreadInitialized = true;
+                    $selectResult                  = 1;
+                } else {
+                    $readArray    = [$this->socket];
+                    $writeArray   = null;
+                    $exceptArray  = null;
+                    $selectResult = \stream_select($readArray, $writeArray, $exceptArray, 0);
+                }
+                // 1 means there is data to read, false means we were unable to check if there is data to read
+                if ($selectResult === 1 || $selectResult === false) {
+                    $result                        = \fread($this->socket, $length);
                     $this->hasBeenFreadInitialized = true;
                 } else {
                     $result = false;
                 }
+
                 if ($makeBlockingAfterRead) {
                     \stream_set_blocking($this->socket, true);
                     $makeBlockingAfterRead = false;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -116,7 +116,8 @@ class ClientTest extends BaseTest
 
             $bytes = $instance->sendData('baz', Protocol::TYPE_TEXT);
             self::assertTrue($bytes >= 3, 'sent text frame');
-
+            self::assertSame([], $instance->receive(), 'Instantly recieve after send');
+            \usleep(500000);
             // test fix for issue #43
             $responses = $instance->receive();
             self::assertTrue(\is_array($responses));


### PR DESCRIPTION
There is an issue where this fread can block up to 5 seconds when there is nothing to read.

Fix it by not issuing fread() if stream_select() say there is nothing to read.

Also encountered a strange issue on PHP8.4.12 Ubuntu24.04 where stream_select() would incorrectly return 0 if we had never ran fread() on the socket, so made a workaround to always call fread the first time.


- resolves https://github.com/chrome-php/chrome/issues/711
- resolves https://github.com/chrome-php/chrome/issues/646

- probably resolves https://github.com/chrome-php/chrome/issues/704
- probably resolves https://github.com/chrome-php/chrome/issues/710
- probably resolves https://github.com/chrome-php/chrome/issues/669

Reproduce script: 
```php
<?php

declare(strict_types=1);
require_once(__DIR__ . '/vendor/autoload.php');
$chromeBinary = "/snap/bin/chromium";
$browser_factory = new \HeadlessChromium\BrowserFactory($chromeBinary);
$browser_factory->setOptions([
    "headless" => true,
    "noSandbox" => true,
    'customFlags' => [
        // docker ...
        '--disable-dev-shm-usage',
    ]
]);
$browser = $browser_factory->createBrowser();
$page = $browser->createPage();
$highscore = -INF;
$page->navigate("http://example.com")->waitForNavigation();

for ($i = 0; $i < 100; ++$i) {
$t = microtime(true);
$url = $page->getCurrentUrl();
$t = microtime(true) - $t;
if ($t > $highscore) {
    echo "New highscore: $t seconds for $url\n";
    $highscore = $t;
}
}
```
output before this patch:
```
hans@DESKTOP-EE15SLU:~/projects/chrome/hans$ php reproduce.php 
New highscore: 1.0967254638672E-5 seconds for getCurrentUrl() on https://example.com/
New highscore: 0.0005338191986084 seconds for getCurrentUrl() on https://example.com/
New highscore: 0.021073818206787 seconds for getCurrentUrl() on https://example.com/
New highscore: 0.96735405921936 seconds for getCurrentUrl() on https://example.com/
New highscore: 3.1658289432526 seconds for getCurrentUrl() on https://example.com/
New highscore: 5.0055141448975 seconds for getCurrentUrl() on https://example.com/
New highscore: 5.0062091350555 seconds for getCurrentUrl() on https://example.com/
New highscore: 5.0073070526123 seconds for getCurrentUrl() on https://example.com/
New highscore: 5.0073978900909 seconds for getCurrentUrl() on https://example.com/
New highscore: 5.0115480422974 seconds for getCurrentUrl() on https://example.com/
^C
```
-first took microseconds, then milliseconds, then 3 seconds, then consistently 5 seconds..
(Had to ctrl+c cancel it because it was taking so long...)
Output after this patch:
```
hans@DESKTOP-EE15SLU:~/projects/chrome/hans$ php reproduce.php 
New highscore: 9.0599060058594E-6 seconds for getCurrentUrl() on https://example.com/
hans@DESKTOP-EE15SLU:~/projects/chrome/hans$ php reproduce.php 
New highscore: 5.9604644775391E-6 seconds for getCurrentUrl() on https://example.com/
hans@DESKTOP-EE15SLU:~/projects/chrome/hans$ php reproduce.php 
New highscore: 1.0967254638672E-5 seconds for getCurrentUrl() on https://example.com/
New highscore: 2.0027160644531E-5 seconds for getCurrentUrl() on https://example.com/
hans@DESKTOP-EE15SLU:~/projects/chrome/hans$ 
```
- Consistently execute in microseconds 👍 