### PR TITLE
[1.8] Prevent blocking empty fread()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -237,6 +237,10 @@ class Client extends Configurable
         );
 
         $this->socket->send($handshake);
+
+        // wait for the response to arrive, since receive() does not block waiting for data
+        $this->waitForData(ClientSocket::TIMEOUT_SOCKET);
+
         $response = $this->socket->receive(self::MAX_HANDSHAKE_RESPONSE);
 
         return $this->connected =
@@ -296,21 +300,6 @@ class Client extends Configurable
      */
     public function waitForData(float $maxSeconds): ?bool
     {
-        $read = [$this->socket->getResource()];
-        $write = null;
-        $except = null;
-        $seconds = (int) \floor($maxSeconds);
-        $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
-        $result = \stream_select($read, $write, $except, $seconds, $microseconds);
-        if (false === $result) {
-            // An error occurred. stream_select() probably triggered an error internally.
-            return null;
-        } elseif (0 === $result) {
-            // Timeout occurred, no data available
-            return false;
-        }
-
-        // Data is available
-        return true;
+        return $this->socket->waitForData($maxSeconds);
     }
 }

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -57,6 +57,13 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
     protected $name;
 
     /**
+     * Whether we have ran fread() on the socket at least once.
+     *
+     * @var bool
+     */
+    private $hasBeenFreadInitialized = false;
+
+    /**
      * Gets the IP address of the socket.
      *
      * @throws \Wrench\Exception\SocketException If the IP address cannot be obtained
@@ -242,8 +249,22 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
                     return $buffer;
                 }
-
-                $result = \fread($this->socket, $length);
+                if (!$this->hasBeenFreadInitialized) {
+                    // stream_select() may erroneously return 0 before the first fread() (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
+                    $this->hasBeenFreadInitialized = true;
+                    $selectResult = 1;
+                } else {
+                    $readArray = [$this->socket];
+                    $writeArray = null;
+                    $exceptArray = null;
+                    $selectResult = \stream_select($readArray, $writeArray, $exceptArray, 0);
+                }
+                // 1 means there is data to read, false means we were unable to check if there is data to read
+                if (1 === $selectResult || false === $selectResult) {
+                    $result = \fread($this->socket, $length);
+                } else {
+                    $result = false;
+                }
 
                 if ($makeBlockingAfterRead) {
                     \stream_set_blocking($this->socket, true);

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -57,13 +57,6 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
     protected $name;
 
     /**
-     * Whether we have ran fread() on the socket at least once.
-     *
-     * @var bool
-     */
-    private $hasBeenFreadInitialized = false;
-
-    /**
      * Gets the IP address of the socket.
      *
      * @throws \Wrench\Exception\SocketException If the IP address cannot be obtained
@@ -232,6 +225,33 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
     }
 
     /**
+     * Waits for data to become available on the socket.
+     *
+     * @param float $maxSeconds the maximum amount of time to wait for data, in seconds
+     *
+     * @return ?bool returns true if data is available, false if the wait timed out, and null on error
+     */
+    public function waitForData(float $maxSeconds): ?bool
+    {
+        $read = [$this->socket];
+        $write = null;
+        $except = null;
+        $seconds = (int) \floor($maxSeconds);
+        $microseconds = (int) (($maxSeconds - $seconds) * 1e6);
+        $result = @\stream_select($read, $write, $except, $seconds, $microseconds);
+        if (false === $result) {
+            // An error occurred. stream_select() probably triggered an error internally.
+            return null;
+        } elseif (0 === $result) {
+            // Timeout occurred, no data available
+            return false;
+        }
+
+        // Data is available
+        return true;
+    }
+
+    /**
      * Receive data from the socket.
      */
     public function receive(int $length = self::DEFAULT_RECEIVE_LENGTH): string
@@ -249,16 +269,13 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
                     return $buffer;
                 }
-                if (!$this->hasBeenFreadInitialized) {
-                    // stream_select() may erroneously return 0 before the first fread() (observed on PHP8.4.12 Ubuntu24.04 chrome-php/wrench1.8.0)
-                    $this->hasBeenFreadInitialized = true;
-                    $selectResult = 1;
-                } else {
-                    $readArray = [$this->socket];
-                    $writeArray = null;
-                    $exceptArray = null;
-                    $selectResult = \stream_select($readArray, $writeArray, $exceptArray, 0);
-                }
+                // poll before reading so that an empty socket returns immediately instead
+                // of blocking until the socket timeout; callers that expect a reply must
+                // wait for data to arrive before reading, as the handshake does
+                $readArray = [$this->socket];
+                $writeArray = null;
+                $exceptArray = null;
+                $selectResult = \stream_select($readArray, $writeArray, $exceptArray, 0);
                 // 1 means there is data to read, false means we were unable to check if there is data to read
                 if (1 === $selectResult || false === $selectResult) {
                     $result = \fread($this->socket, $length);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -116,7 +116,7 @@ class ClientTest extends BaseTest
 
             $bytes = $instance->sendData('baz', Protocol::TYPE_TEXT);
             self::assertTrue($bytes >= 3, 'sent text frame');
-            self::assertSame([], $instance->receive(), 'Instantly recieve after send');
+            self::assertSame([], $instance->receive(), 'Instantly receive after send');
             \usleep(500000);
             // test fix for issue #43
             $responses = $instance->receive();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -116,7 +116,8 @@ class ClientTest extends BaseTest
 
             $bytes = $instance->sendData('baz', Protocol::TYPE_TEXT);
             self::assertTrue($bytes >= 3, 'sent text frame');
-
+            self::assertSame([], $instance->receive(), 'Instantly recieve after send');
+            \usleep(500000);
             // test fix for issue #43
             $responses = $instance->receive();
             self::assertTrue(\is_array($responses));

--- a/tests/Socket/ClientSocketTest.php
+++ b/tests/Socket/ClientSocketTest.php
@@ -132,6 +132,8 @@ Origin: http://localhost\r
 Sec-WebSocket-Version: 13\r\n\r\n");
             self::assertNotEquals(false, $sent, 'Client socket can send to test server');
 
+            self::assertTrue($instance->waitForData(AbstractSocket::TIMEOUT_SOCKET), 'Data arrives from test server');
+
             $response = $instance->receive();
             self::assertStringStartsWith('HTTP', $response, 'Response looks like HTTP handshake response');
         } catch (\Exception $e) {

--- a/tests/Socket/ServerClientSocketTest.php
+++ b/tests/Socket/ServerClientSocketTest.php
@@ -35,4 +35,31 @@ class ServerClientSocketTest extends SocketBaseTest
 
         $instance->getPort();
     }
+
+    public function testReceiveReturnsImmediatelyWhenNoDataIsAvailable(): void
+    {
+        [$local, $remote] = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $instance = self::getInstance($local);
+
+        $start = \microtime(true);
+        $received = $instance->receive();
+
+        self::assertSame('', $received);
+        self::assertLessThan(2, \microtime(true) - $start, 'receive did not block on an empty socket');
+
+        \fclose($remote);
+    }
+
+    public function testReceiveReturnsDataAlreadyAvailable(): void
+    {
+        [$local, $remote] = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $sent = \str_repeat('a', 2 * AbstractSocket::DEFAULT_RECEIVE_LENGTH);
+        \fwrite($remote, $sent);
+
+        $instance = self::getInstance($local);
+
+        self::assertSame($sent, $instance->receive());
+
+        \fclose($remote);
+    }
 }


### PR DESCRIPTION
This supersedes #26. When there is nothing to read, receive() issues a blocking fread() that stalls for up to five seconds. chrome-php drains pending events by reading until the socket is empty, so the final read of every drain paid the full socket timeout, which is the cause of the slowdowns reported in chrome-php/chrome#711 and the slow disconnects in chrome-php/chrome#646. The first commit is the original fix by @divinity76, squashed from #26, which polls stream_select() with a zero timeout before reading so that an empty socket returns immediately. The second commit replaces the workaround that exempted the first ever read on a socket from that poll. The exemption existed because the handshake read in Client::connect() relied on fread() blocking until the server's reply arrived, but since the flag was never reset it only worked for the first connection: reconnecting on the same socket object would poll immediately after sending the upgrade request, read nothing, and fail the handshake. Instead, receive() now never blocks waiting for data, and connect() waits for the reply explicitly using waitForData(), which has moved from the client down to the socket so that both the client and the raw socket tests can use it. The server is unaffected, since it only reads from sockets that its own stream_select() loop reported readable.