### PR TITLE
[1.9] Add an optional wait for data to receive()

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $server->run();
 $client = new Client('ws://localhost:8000', 'http://localhost:8000');
 $client->connect();
 $client->sendData('hello');
-$response = $client->receive()[0]->getPayload();
+$response = $client->receive(5.0)[0]->getPayload();
 $client->disconnect();
 ```
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use Wrench\Exception\SocketException;
 use Wrench\Payload\Payload;
 use Wrench\Payload\PayloadHandler;
 use Wrench\Protocol\Protocol;
+use Wrench\Socket\AbstractSocket;
 use Wrench\Socket\ClientSocket;
 use Wrench\Util\Configurable;
 
@@ -187,15 +188,17 @@ class Client extends Configurable
     /**
      * Receives data sent by the server.
      *
+     * @param float $waitSeconds the maximum amount of time to wait for data, in seconds
+     *
      * @return array<Payload> Payload received since the last call to receive()
      */
-    public function receive(): ?array
+    public function receive(float $waitSeconds = 0.0): ?array
     {
         if (!$this->isConnected()) {
             return null;
         }
 
-        $data = $this->socket->receive();
+        $data = $this->socket->receive(AbstractSocket::DEFAULT_RECEIVE_LENGTH, $waitSeconds);
 
         if (!$data) {
             return [];
@@ -239,9 +242,7 @@ class Client extends Configurable
         $this->socket->send($handshake);
 
         // wait for the response to arrive, since receive() does not block waiting for data
-        $this->waitForData(ClientSocket::TIMEOUT_SOCKET);
-
-        $response = $this->socket->receive(self::MAX_HANDSHAKE_RESPONSE);
+        $response = $this->socket->receive(self::MAX_HANDSHAKE_RESPONSE, ClientSocket::TIMEOUT_SOCKET);
 
         return $this->connected =
             $this->protocol->validateResponseHandshake($response, $key);

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -253,9 +253,18 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
 
     /**
      * Receive data from the socket.
+     *
+     * Data that has already arrived is drained without blocking. Pass a wait
+     * time to also wait for up to that many seconds for data to first arrive.
+     *
+     * @param float $waitSeconds the maximum amount of time to wait for data, in seconds
      */
-    public function receive(int $length = self::DEFAULT_RECEIVE_LENGTH): string
+    public function receive(int $length = self::DEFAULT_RECEIVE_LENGTH, float $waitSeconds = 0.0): string
     {
+        if ($waitSeconds > 0) {
+            $this->waitForData($waitSeconds);
+        }
+
         $buffer = '';
         $metadata['unread_bytes'] = 0;
         $makeBlockingAfterRead = false;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -117,9 +117,8 @@ class ClientTest extends BaseTest
             $bytes = $instance->sendData('baz', Protocol::TYPE_TEXT);
             self::assertTrue($bytes >= 3, 'sent text frame');
             self::assertSame([], $instance->receive(), 'Instantly receive after send');
-            \usleep(500000);
             // test fix for issue #43
-            $responses = $instance->receive();
+            $responses = $instance->receive(5.0);
             self::assertTrue(\is_array($responses));
             self::assertCount(1, $responses);
             self::assertInstanceOf(Payload::class, $responses[0]);

--- a/tests/Socket/ServerClientSocketTest.php
+++ b/tests/Socket/ServerClientSocketTest.php
@@ -62,4 +62,34 @@ class ServerClientSocketTest extends SocketBaseTest
 
         \fclose($remote);
     }
+
+    public function testReceiveWaitsForDataToArrive(): void
+    {
+        [$local, $remote] = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        $instance = self::getInstance($local);
+
+        $start = \microtime(true);
+        $received = $instance->receive(AbstractSocket::DEFAULT_RECEIVE_LENGTH, 0.2);
+
+        self::assertSame('', $received);
+        self::assertGreaterThan(0.1, \microtime(true) - $start, 'receive waited for data to arrive');
+
+        \fclose($remote);
+    }
+
+    public function testReceiveDoesNotWaitWhenDataIsAvailable(): void
+    {
+        [$local, $remote] = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        \fwrite($remote, 'foobar');
+
+        $instance = self::getInstance($local);
+
+        $start = \microtime(true);
+        $received = $instance->receive(AbstractSocket::DEFAULT_RECEIVE_LENGTH, 5.0);
+
+        self::assertSame('foobar', $received);
+        self::assertLessThan(2, \microtime(true) - $start, 'receive returned as soon as data was available');
+
+        \fclose($remote);
+    }
 }


### PR DESCRIPTION
Since #28, receive() drains data that has already arrived and never blocks waiting for data to arrive, which left consumers without a sanctioned way to say wait up to some amount of time for data and then drain it, short of pairing waitForData() with receive() by hand as connect() did. This adds an optional wait time to AbstractSocket::receive() and Client::receive(), implemented as a single bounded stream_select() before the existing drain, so the call wakes the moment data lands and simply returns empty on timeout. connect() now passes its timeout to receive() instead of performing the two-step wait, and the client example in the README, which implicitly relied on the old blocking behaviour, now passes a wait time too. Note that adding an optional parameter is technically a breaking change for any subclass that overrides these two methods without it, which is why this targets 1.9 rather than a 1.8 patch. chrome-php will rely on this release line to park on the socket instead of polling while awaiting responses.