### PR TITLE
[1.8] Release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 1.8.1 (2026-07-06)
+
+* Prevent blocking on empty `fread()` calls
+
+
 ## 1.8.0 (2025-12-27)
 
 * Add support for PHP 8.5


### PR DESCRIPTION
This prepares the 1.8.1 release, dated 2026-07-06, whose only user-facing change since 1.8.0 is #28, preventing blocking on empty `fread()` calls. The other commits on the branch are tooling changes that are not listed in the changelog, consistent with past releases.