### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # CHANGELOG
 
 
-## 1.9.0 (UPCOMING)
+## 1.9.0 (2026-07-06)
 
-* Prevent blocking empty `fread()`
 * Add an optional wait for data to `receive()`
 
 


### PR DESCRIPTION
This prepares the 1.9.0 release changelog by setting the release date and removing the duplicate 1.8.1 fread fix from the 1.9.0 notes.