### PR TITLE
Fix waitForData crash when the socket is disconnected

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -302,6 +302,10 @@ class Client extends Configurable
      */
     public function waitForData(float $maxSeconds): ?bool
     {
+        if (!$this->isConnected()) {
+            return null;
+        }
+
         return $this->socket->waitForData($maxSeconds);
     }
 }

--- a/src/Socket/AbstractSocket.php
+++ b/src/Socket/AbstractSocket.php
@@ -233,6 +233,10 @@ abstract class AbstractSocket extends Configurable implements ResourceInterface
      */
     public function waitForData(float $maxSeconds): ?bool
     {
+        if (null === $this->socket) {
+            return null;
+        }
+
         $read = [$this->socket];
         $write = null;
         $except = null;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -89,6 +89,7 @@ class ClientTest extends BaseTest
             $instance->addRequestHeader('X-Test', 'Custom Request Header');
 
             self::assertNull($instance->receive(), 'Receive before connect');
+            self::assertNull($instance->waitForData(0), 'Wait for data before connect');
 
             $success = $instance->connect();
             self::assertTrue($success, 'Client can connect to test server');
@@ -123,6 +124,7 @@ class ClientTest extends BaseTest
             $instance->disconnect();
 
             self::assertFalse($instance->isConnected());
+            self::assertNull($instance->waitForData(0), 'Wait for data after disconnect');
         } finally {
             $helper->tearDown();
         }

--- a/tests/Socket/ClientSocketTest.php
+++ b/tests/Socket/ClientSocketTest.php
@@ -110,6 +110,13 @@ class ClientSocketTest extends UriSocketBaseTest
         $instance->send('foo');
     }
 
+    public function testWaitForDataTooEarly(): void
+    {
+        $instance = self::getInstance('ws://localhost:8000');
+
+        self::assertNull($instance->waitForData(0));
+    }
+
     /**
      * Test the connect, send, receive method.
      */


### PR DESCRIPTION
The waitForData() method added in 1.9.0 calls stream_select() without checking that the socket resource still exists. When the peer closes the connection, receive() detects EOF and disconnects the socket, setting the underlying resource to null, so a subsequent waitForData() call passes null to stream_select(), which throws a ValueError on PHP 8 that the @ suppression cannot catch. This surfaced as a flaky teardown failure in chrome-php/chrome, where Chrome 140 closes the DevTools WebSocket during shutdown while the client is still waiting for a response. This change makes AbstractSocket::waitForData() return null when the socket is gone, matching the documented error contract of that method, and makes Client::waitForData() check the connection state first, consistent with sendData() and receive().