### PR TITLE
Tighten handshake validation and freeze trim characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 1.9.2 (Unreleased)
+
+* Reject handshake request lines with a bare line feed ending or a non-literal HTTP version
+* Match `server_ssl_` socket option keys to the true end of input
+* Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
+
 ## 1.9.1 (2026-07-06)
 
 * Fix `waitForData` crash when the socket is disconnected

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -120,7 +120,7 @@ abstract class Protocol
     /**
      * Used for parsing requested path. preg_* compatible.
      */
-    public const REQUEST_LINE_REGEX = '/^GET (\S+) HTTP\/1.1$/';
+    public const REQUEST_LINE_REGEX = '/^GET (\S+) HTTP\/1\.1$/D';
 
     /**
      * printf compatible.
@@ -459,9 +459,9 @@ abstract class Protocol
         $statusCode = $this->getStatusCode($response);
 
         if (self::HTTP_SWITCHING_PROTOCOLS !== $statusCode) {
-            $errorMessage = \explode("\n", \trim($this->getBody($response)), 2)[0];
+            $errorMessage = \explode("\n", \trim($this->getBody($response), " \n\r\t\0\x0B"), 2)[0];
 
-            throw new HandshakeException(\trim(\sprintf('Expected handshake response status code %d, but received %d. %s', self::HTTP_SWITCHING_PROTOCOLS, $statusCode, $errorMessage)));
+            throw new HandshakeException(\trim(\sprintf('Expected handshake response status code %d, but received %d. %s', self::HTTP_SWITCHING_PROTOCOLS, $statusCode, $errorMessage), " \n\r\t\0\x0B"));
         }
 
         $acceptHeaderValue = $this->getHeaders($response)[self::HEADER_ACCEPT] ?? '';
@@ -510,12 +510,12 @@ abstract class Protocol
             if (2 == \count($parts)) {
                 [$name, $value] = $parts;
                 if (!isset($return[$name])) {
-                    $return[$name] = \trim($value);
+                    $return[$name] = \trim($value, " \n\r\t\0\x0B");
                 } else {
                     if (\is_array($return[$name])) {
-                        $return[$name][] = \trim($value);
+                        $return[$name][] = \trim($value, " \n\r\t\0\x0B");
                     } else {
-                        $return[$name] = [$return[$name], \trim($value)];
+                        $return[$name] = [$return[$name], \trim($value, " \n\r\t\0\x0B")];
                     }
                 }
             }
@@ -608,7 +608,7 @@ abstract class Protocol
             throw new BadRequestException('No key header received');
         }
 
-        $key = \trim($headers[self::HEADER_KEY]);
+        $key = \trim($headers[self::HEADER_KEY], " \n\r\t\0\x0B");
 
         if (!$key) {
             throw new BadRequestException('Invalid key');

--- a/src/Socket/ServerSocket.php
+++ b/src/Socket/ServerSocket.php
@@ -113,7 +113,7 @@ class ServerSocket extends UriSocket
 
         // Otherwise map any options through
         foreach ($this->options as $option => $value) {
-            if (\preg_match('/^server_ssl_(.*)$/', $option, $matches)) {
+            if (\preg_match('/^server_ssl_(.*)$/D', $option, $matches)) {
                 $options[$matches[1]] = $value;
             }
         }

--- a/tests/Protocol/ProtocolBaseTest.php
+++ b/tests/Protocol/ProtocolBaseTest.php
@@ -4,6 +4,7 @@ namespace Wrench\Protocol;
 
 use Exception;
 use InvalidArgumentException;
+use Wrench\Exception\BadRequestException;
 use Wrench\Test\BaseTest;
 
 abstract class ProtocolBaseTest extends BaseTest
@@ -33,6 +34,16 @@ abstract class ProtocolBaseTest extends BaseTest
         } catch (Exception $e) {
             $this->fail($e);
         }
+    }
+
+    /**
+     * @dataProvider getInvalidHandshakeRequestLines
+     */
+    public function testValidateHandshakeRequestLineInvalid(string $request): void
+    {
+        $this->expectException(BadRequestException::class);
+
+        self::getInstance()->validateRequestHandshake($request);
     }
 
     /**
@@ -158,6 +169,22 @@ Sec-WebSocket-Version: 13\r
 \r\n"];
 
         return $cases;
+    }
+
+    public static function getInvalidHandshakeRequestLines(): array
+    {
+        $headers = "Host: server.example.com\r
+Upgrade: websocket\r
+Connection: Upgrade\r
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
+Origin: http://example.com\r
+Sec-WebSocket-Version: 13\r
+\r\n";
+
+        return [
+            'bare line feed ending the request line' => ["GET /chat HTTP/1.1\n\r\n".$headers],
+            'non-literal HTTP version' => ["GET /chat HTTP/1x1\r\n".$headers],
+        ];
     }
 
     public static function getValidHandshakeResponses(): array


### PR DESCRIPTION
Without the PCRE `D` modifier a trailing `$` anchor also matches immediately before a final newline, and `getRequestHeaders` cuts the handshake request line at the first CRLF, so a client sending a bare line feed before its first CRLF produced a request line with a trailing newline that still validated. The request-line pattern also left both dots in `HTTP/1.1` unescaped, so versions such as `HTTP/1x1` were accepted. The pattern now escapes the dots and carries `D`, the `server_ssl_` option-key pattern gains the same anchor, and a new test pins both rejections through `validateRequestHandshake`.

This also passes the pre-8.6 trim character set explicitly at the six calls that relied on the PHP default, in the handshake header parsing, key extraction, and failure diagnostics, since PHP 8.6 adds form feed to that default. This is the wrench counterpart of chrome-php/chrome#751.
